### PR TITLE
Upgrade to Gatsby v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://gatsby-theme-forty.netlify.com
 
 Install this theme (assuming Gatsby is installed) by running from your CLI:
 
-```
+```shell
 gatsby new gatsby-theme-forty https://github.com/codebushi/gatsby-theme-forty
 cd gatsby-theme-forty
 gatsby develop
@@ -18,11 +18,12 @@ gatsby develop
 
 ## Updates
 
-Compared to the original work, 
+Compared to the original work,
 
-* The Gastby used by this package has been bumped from 2 to 3.
+* The Gatsby used by this package has been bumped from 2 to 3.
 * The sass version has been bumped to sass 2.
 * Drop some deprecated sass usages.
+* Drop `javascript:;` deprecated by `React`.
 
 ## CSS Grid
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ cd gatsby-theme-forty
 gatsby develop
 ```
 
+## Updates
+
+Compared to the original work, 
+
+* The Gastby used by this package has been bumped from 2 to 3.
+* The sass version has been bumped to sass 2.
+* Drop some deprecated sass usages.
+
 ## CSS Grid
 
 The grid on this site was replaced with a custom version, built using CSS Grid. It's a very simple 12 column grid that is disabled on mobile. To start using the grid, wrap the desired items with `grid-wrapper`. Items inside the `grid-wrapper` use the class `col-` followed by a number, which should add up to 12.
 
 Here is an example of using the grid, for a 3 column layout:
 
-```
+```jsx
 <div className="grid-wrapper">
     <div className="col-4">
         <p>Content Here</p>

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "version": "1.0.4",
   "author": "Hunter Chang",
   "dependencies": {
-    "gatsby-plugin-manifest": "^2.2.4",
-    "gatsby-plugin-offline": "^2.2.4",
-    "gatsby-plugin-page-creator": "^2.1.5",
-    "gatsby-plugin-react-helmet": "^3.1.2",
-    "gatsby-plugin-sass": "^2.1.3",
-    "node-sass": "^4.12.0",
-    "react-helmet": "^5.2.1"
+    "gatsby-plugin-manifest": "^3.10.0",
+    "gatsby-plugin-mdx": "^2.10.1",
+    "gatsby-plugin-offline": "^4.10.0",
+    "gatsby-plugin-page-creator": "^3.10.0",
+    "gatsby-plugin-react-helmet": "^4.10.0",
+    "gatsby-plugin-sass": "^4.10.0",
+    "gatsby-plugin-sitemap": "^4.6.0",
+    "gatsby-source-filesystem": "^3.10.0"
   },
   "keywords": [
     "gatsby",
@@ -25,15 +26,23 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "prettier": "^1.18.2",
-    "gatsby": "^2.13.41",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "prettier": "^2.3.2",
+	"gatsby": "^3.10.2",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-helmet": "^6.1.0",
+    "sass": "^1.37.0",
+	"@mdx-js/mdx": "^1.6.22",
+    "@mdx-js/react": "^1.6.22"
   },
   "peerDependencies": {
-    "gatsby": "^2.13.41",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "gatsby": "^3.10.2",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-helmet": "^6.1.0",
+    "sass": "^1.37.0",
+	"@mdx-js/mdx": "^1.6.22",
+    "@mdx-js/react": "^1.6.22"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "gatsby-plugin-react-helmet": "^4.10.0",
     "gatsby-plugin-sass": "^4.10.0",
     "gatsby-plugin-sitemap": "^4.6.0",
-    "gatsby-source-filesystem": "^3.10.0"
+    "gatsby-source-filesystem": "^3.10.0",
+    "react-helmet": "^6.1.0",
+    "sass": "^1.37.0",
+    "@mdx-js/mdx": "^1.6.22",
+    "@mdx-js/react": "^1.6.22"
   },
   "keywords": [
     "gatsby",
@@ -27,22 +31,14 @@
   },
   "devDependencies": {
     "prettier": "^2.3.2",
-	"gatsby": "^3.10.2",
+    "gatsby": "^3.10.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "react-helmet": "^6.1.0",
-    "sass": "^1.37.0",
-	"@mdx-js/mdx": "^1.6.22",
-    "@mdx-js/react": "^1.6.22"
+    "react-dom": "^17.0.1"
   },
   "peerDependencies": {
     "gatsby": "^3.10.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "react-helmet": "^6.1.0",
-    "sass": "^1.37.0",
-	"@mdx-js/mdx": "^1.6.22",
-    "@mdx-js/react": "^1.6.22"
+    "react-dom": "^17.0.1"
   },
   "repository": {
     "type": "git",

--- a/src/assets/scss/base/_typography.scss
+++ b/src/assets/scss/base/_typography.scss
@@ -6,6 +6,8 @@
 
 /* Type */
 
+@use "sass:math";
+
 body,
 input,
 select,
@@ -51,9 +53,9 @@ a {
     color: desaturate(darken(_palette(highlight), 15), 5) !important;
   }
 
-  &:focus {
+  /*&:focus {
     outline: 3px solid rgba(155, 241, 255, 0.5);
-  }
+  }*/
 }
 
 strong,
@@ -142,7 +144,7 @@ blockquote {
   border-left: solid 4px _palette(border);
   font-style: italic;
   margin: 0 0 _size(element-margin) 0;
-  padding: (_size(element-margin) / 4) 0 (_size(element-margin) / 4)
+  padding: math.div(_size(element-margin), 4) 0 math.div(_size(element-margin), 4)
     _size(element-margin);
 }
 

--- a/src/assets/scss/components/_tiles.scss
+++ b/src/assets/scss/components/_tiles.scss
@@ -72,10 +72,10 @@
       z-index: 4;
     }
 
-    .link.primary:focus,
+    /*.link.primary:focus,
     .link.primary:focus h3 {
       outline: 3px solid rgba(155, 241, 255, 0.5);
-    }
+    }*/
 
     &:before {
       @include vendor('transition', 'opacity 0.5s ease');

--- a/src/assets/scss/layout/_header.scss
+++ b/src/assets/scss/layout/_header.scss
@@ -70,9 +70,9 @@
       }
     }
 
-    &:focus {
+    /*&:focus {
       outline: 3px solid rgba(155, 241, 255, 0.5);
-    }
+    }*/
   }
 
   nav {
@@ -92,9 +92,9 @@
       position: relative;
       vertical-align: middle;
 
-      &:focus {
+      /*&:focus {
         outline: 3px solid rgba(155, 241, 255, 0.5);
-      }
+      }*/
 
       &:last-child {
         padding-right: 1.5em;

--- a/src/assets/scss/libs/_skel.scss
+++ b/src/assets/scss/libs/_skel.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: ();
 
 	/// Vendor prefixes.
 	/// @var {list}
@@ -573,7 +573,7 @@
 			}
 
 		// Expand just the value?
-			@elseif $expandValue {
+			@else if $expandValue {
 			    @each $vendor in $vendor-prefixes {
 			        #{$property}: #{str-replace-all($value, '-prefix-', $vendor)};
 			    }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,7 @@ const Header = (props) => (
     <header id="header" className="alt">
         <Link to="/" className="logo"><strong>Forty</strong> <span>by HTML5 UP</span></Link>
         <nav>
-            <a className="menu-link" onClick={props.onToggleMenu} href="javascript:;">Menu</a>
+            <a className="menu-link" onClick={props.onToggleMenu}>Menu</a>
         </nav>
     </header>
 )

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -16,7 +16,7 @@ const Menu = (props) => (
                 <li><a href="#" className="button fit">Log In</a></li>
             </ul>
         </div>
-        <a className="close" onClick={props.onToggleMenu} href="javascript:;">Close</a>
+        <a className="close" onClick={props.onToggleMenu}>Close</a>
     </nav>
 )
 


### PR DESCRIPTION
First, let me thank the author for such an awesome theme.

The last time this project is updated is 2 years ago. Now some of the features in this project are out-of-date. So I make such modifications:

* The Gatsby used by this package has been bumped from 2 to 3.
* The sass version has been bumped to sass 2.
* Drop some deprecated sass usages.
* Drop `javascript:;` deprecated by `React`.

The above modifications will upgrade this project to Gatsby v3, and remove all warnings caused by deprecations.

If the author is willing to accept this PR, for the compatibility issue, I suggest that the author should

* add a branch named as `gatsby-v3` and merge my PR to that one,
* or backup the current `master` branch as `gatsby-v2` and merge my PR to `master`.

Thank you!